### PR TITLE
Feature/fatigue mjx

### DIFF
--- a/myosuite/envs/myo/fatigue.py
+++ b/myosuite/envs/myo/fatigue.py
@@ -70,6 +70,7 @@ class CumulativeFatigue:
 
         # Calculate C(t) -- transfer rate between MR and MA
         C = np.zeros_like(self._MA)
+        print (self._MA, self.TL, self._MR)
         idxs = (self._MA < self.TL) & (self._MR > (self.TL - self._MA))
         C[idxs] = self._LD[idxs] * (self.TL[idxs] - self._MA[idxs])
         idxs = (self._MA < self.TL) & (self._MR <= (self.TL - self._MA))

--- a/myosuite/envs/myo/fatigue.py
+++ b/myosuite/envs/myo/fatigue.py
@@ -70,7 +70,6 @@ class CumulativeFatigue:
 
         # Calculate C(t) -- transfer rate between MR and MA
         C = np.zeros_like(self._MA)
-        print (self._MA, self.TL, self._MR)
         idxs = (self._MA < self.TL) & (self._MR > (self.TL - self._MA))
         C[idxs] = self._LD[idxs] * (self.TL[idxs] - self._MA[idxs])
         idxs = (self._MA < self.TL) & (self._MR <= (self.TL - self._MA))

--- a/myosuite/mjx/fatigue.py
+++ b/myosuite/mjx/fatigue.py
@@ -16,7 +16,7 @@ class CumulativeFatigue:
     Adapted from https://dl.acm.org/doi/pdf/10.1145/3313831.3376701
     Based on implementation from Aleksi Ikkala and Florian Fischer
     """
-    def __init__(self, mj_model, frame_skip=1, key=None):
+    def __init__(self, mj_model, frame_skip=1):
         # Get muscle actuator indices
         muscle_act_ind = mj_model.actuator_dyntype == mujoco.mjtDyn.mjDYN_MUSCLE
         # Convert to concrete integer value
@@ -46,8 +46,6 @@ class CumulativeFatigue:
             if muscle_act_ind[i]
         ], dtype=jp.float32)
         
-        # Static values (will be included in aux_data)
-        self.key = key
 
     def _tree_flatten(self) -> Tuple[Tuple[Any, ...], Dict]:
         """Flatten the class into children and auxiliary data"""
@@ -60,8 +58,7 @@ class CumulativeFatigue:
         
         # Static values
         aux_data = {
-            'na': self.na,
-            'key': self.key
+            'na': self.na
         }
         return (children, aux_data)
 
@@ -77,10 +74,9 @@ class CumulativeFatigue:
         
         # Restore static values
         obj.na = aux_data['na']
-        obj.key = aux_data['key']
         return obj
 
-    @jax.jit
+    # @jax.jit
     def compute_act(self, act):
         """
         Compute muscle activation considering fatigue
@@ -140,16 +136,16 @@ class CumulativeFatigue:
         
         return self.MA, self.MR, self.MF
 
-    @jax.jit
+    # @jax.jit
     def get_effort(self):
         """Calculate effort as norm of difference between actual and target activation"""
         return jp.linalg.norm(self.MA - self.TL)
 
-    def reset(self, fatigue_reset_vec=None, fatigue_reset_random=False):
+    def reset(self, fatigue_reset_vec=None, fatigue_reset_random=False, key=None):
         """Reset fatigue states"""
         if fatigue_reset_random:
             assert fatigue_reset_vec is None, "Cannot use fatigue_reset_vec if fatigue_reset_random=True"
-            self.key, key1, key2 = jrandom.split(self.key, 3)
+            key1, key2 = jrandom.split(key)
             non_fatigued_muscles = jrandom.uniform(key1, (self.na,))
             active_percentage = jrandom.uniform(key2, (self.na,))
             self.MA = non_fatigued_muscles * active_percentage
@@ -185,47 +181,3 @@ tree_util.register_pytree_node(
     CumulativeFatigue._tree_flatten,
     CumulativeFatigue._tree_unflatten
 )
-
-
-# import cProfile
-# import pstats
-# import io
-
-# def main():
-#     # Create a mock model and key for testing
-#     class MockModel:
-#         def __init__(self):
-#             self.actuator_dyntype = np.array([mujoco.mjtDyn.mjDYN_MUSCLE] * 5)
-#             self.actuator_dynprm = np.array([[0.1, 0.2]] * 5)
-#             self.opt = type('opt', (object,), {'timestep': 0.01})
-
-#     model = MockModel()
-#     key = jrandom.PRNGKey(0)
-
-#     # Initialize the CumulativeFatigue class
-#     fatigue = CumulativeFatigue(model, frame_skip=1, key=key)
-
-#     # Define a batch of test activations
-#     batch_size = 10
-#     test_acts = jp.array([[0.5, 0.6, 0.7, 0.8, 0.9]] * batch_size, dtype=jp.float32)
-
-#     # Define a batched computation using vmap
-#     def batched_compute_act(keys, acts):
-#         def single_compute(key, act):
-#             fatigue_instance = CumulativeFatigue(model, frame_skip=1, key=key)
-#             return fatigue_instance.compute_act(act)
-#         return jax.vmap(single_compute)(keys, acts)
-
-#     # Generate a batch of keys
-#     keys = jrandom.split(key, batch_size)
-
-#     # Profile the batched computation
-#     batched_compute_act(keys, test_acts)
-
-# if __name__ == '__main__':
-#     profiler = cProfile.Profile()
-#     profiler.enable()
-#     main()
-#     profiler.disable()
-#     stats = pstats.Stats(profiler).sort_stats('cumtime')
-#     stats.print_stats(10)  # Print the top 10 functions by cumulative time

--- a/myosuite/mjx/fatigue.py
+++ b/myosuite/mjx/fatigue.py
@@ -1,0 +1,181 @@
+import jax.numpy as jp
+import jax
+import jax.random as jrandom
+import mujoco
+
+# Constants for floating-point precision
+_FLOAT_EPS = jp.finfo(jp.float32).eps
+_EPS4 = _FLOAT_EPS * 4.0
+
+class CumulativeFatigue:
+    """
+    JAX implementation of the 3CC-r muscle fatigue model
+    Adapted from https://dl.acm.org/doi/pdf/10.1145/3313831.3376701
+    Based on implementation from Aleksi Ikkala and Florian Fischer
+    """
+    def __init__(self, mj_model, frame_skip=1, key=None):
+        # Recovery time multiplier (10x factor to compensate for 0.1 below)
+        self._r = 10 * 15  
+        
+        # Fatigue coefficient (identified for elbow torque)
+        self._F = jp.array(0.00912, dtype=jp.float32)
+        
+        # Recovery coefficient (0.1 factor to get ~1% R/F ratio)
+        self._R = jp.array(0.1 * 0.00094, dtype=jp.float32)
+        
+        # Timestep including frame skip
+        self._dt = jp.array(mj_model.opt.timestep * frame_skip, dtype=jp.float32)
+        
+        # Get muscle actuator indices
+        muscle_act_ind = mj_model.actuator_dyntype == mujoco.mjtDyn.mjDYN_MUSCLE
+        self.na = int(jp.sum(muscle_act_ind))  # Number of muscle actuators
+        
+        # Get activation/deactivation time constants for muscles
+        self._tauact = jp.array([
+            mj_model.actuator_dynprm[i][0]
+            for i in range(len(muscle_act_ind))
+            if muscle_act_ind[i]
+        ], dtype=jp.float32)
+        
+        self._taudeact = jp.array([
+            mj_model.actuator_dynprm[i][1]
+            for i in range(len(muscle_act_ind))
+            if muscle_act_ind[i]
+        ], dtype=jp.float32)
+        
+        # Initialize state vectors
+        self._MA = jp.zeros(self.na, dtype=jp.float32)  # Muscle Active
+        self._MR = jp.ones(self.na, dtype=jp.float32)   # Muscle Resting
+        self._MF = jp.zeros(self.na, dtype=jp.float32)  # Muscle Fatigue
+        self.TL = jp.zeros(self.na, dtype=jp.float32)   # Target Load
+        
+        # Initialize RNG
+        self.key = key
+
+    def set_FatigueCoefficient(self, F):
+        """Set Fatigue coefficient"""
+        self._F = jp.array(F, dtype=jp.float32)
+
+    def set_RecoveryCoefficient(self, R):
+        """Set Recovery coefficient"""
+        self._R = jp.array(R, dtype=jp.float32)
+
+    def set_RecoveryMultiplier(self, r):
+        """Set Recovery time multiplier"""
+        self._r = jp.array(r, dtype=jp.float32)
+
+    def compute_act(self, act):
+        """
+        Compute muscle activation considering fatigue
+        
+        Args:
+            act: Target activation levels
+            
+        Returns:
+            tuple: Updated (MA, MR, MF) states
+        """
+        # Set target load
+        self.TL = jp.array(act, dtype=jp.float32)
+        
+        # Calculate effective time constants
+        self._LD = 1 / self._tauact * (0.5 + 1.5 * self._MA)
+        self._LR = (0.5 + 1.5 * self._MA) / self._taudeact
+        
+        # Calculate C(t) - transfer rate between MR and MA
+        C = jp.zeros_like(self._MA)
+        
+        # Case 1: MA < TL and MR > (TL - MA)
+        mask1 = (self._MA < self.TL) & (self._MR > (self.TL - self._MA))
+        C = jp.where(mask1, self._LD * (self.TL - self._MA), C)
+        
+        # Case 2: MA < TL and MR <= (TL - MA)
+        mask2 = (self._MA < self.TL) & (self._MR <= (self.TL - self._MA))
+        C = jp.where(mask2, self._LD * self._MR, C)
+        
+        # Case 3: MA >= TL
+        mask3 = self._MA >= self.TL
+        C = jp.where(mask3, self._LR * (self.TL - self._MA), C)
+        
+        # Calculate recovery rate
+        rR = jp.where(self._MA >= self.TL, 
+                     self._r * self._R,
+                     self._R)
+        
+        # Clip C(t) to ensure states remain between 0 and 1
+        C_min = jp.maximum(
+            -self._MA / self._dt + self._F * self._MA,
+            (self._MR - 1) / self._dt + rR * self._MF
+        )
+        C_max = jp.minimum(
+            (1 - self._MA) / self._dt + self._F * self._MA,
+            self._MR / self._dt + rR * self._MF
+        )
+        C = jp.clip(C, C_min, C_max)
+        
+        # Update states
+        dMA = (C - self._F * self._MA) * self._dt
+        dMR = (-C + rR * self._MF) * self._dt
+        dMF = (self._F * self._MA - rR * self._MF) * self._dt
+        
+        self._MA = self._MA + dMA
+        self._MR = self._MR + dMR
+        self._MF = self._MF + dMF
+        
+        return self._MA, self._MR, self._MF
+
+    def get_effort(self):
+        """Calculate effort as norm of difference between actual and target activation"""
+        return jp.linalg.norm(self._MA - self.TL)
+
+    def reset(self, fatigue_reset_vec=None, fatigue_reset_random=False):
+        """
+        Reset fatigue states
+        
+        Args:
+            fatigue_reset_vec: Optional initial fatigue values
+            fatigue_reset_random: Whether to randomize initial states
+        """
+        if fatigue_reset_random:
+            assert fatigue_reset_vec is None, "Cannot use fatigue_reset_vec if fatigue_reset_random=True"
+            self.key, key1, key2 = jrandom.split(self.key, 3)
+            non_fatigued_muscles = jrandom.uniform(key1, (self.na,))
+            active_percentage = jrandom.uniform(key2, (self.na,))
+            self._MA = non_fatigued_muscles * active_percentage
+            self._MR = non_fatigued_muscles * (1 - active_percentage)
+            self._MF = 1 - non_fatigued_muscles
+        else:
+            if fatigue_reset_vec is not None:
+                assert len(fatigue_reset_vec) == self.na, \
+                    f"Invalid length of fatigue vector (expected {self.na}, got {len(fatigue_reset_vec)})"
+                self._MF = jp.array(fatigue_reset_vec, dtype=jp.float32)
+                self._MR = 1 - self._MF
+                self._MA = jp.zeros(self.na, dtype=jp.float32)
+            else:
+                self._MA = jp.zeros(self.na, dtype=jp.float32)
+                self._MR = jp.ones(self.na, dtype=jp.float32)
+                self._MF = jp.zeros(self.na, dtype=jp.float32)
+
+    # Properties
+    @property
+    def MF(self):
+        return self._MF
+
+    @property
+    def MR(self):
+        return self._MR
+
+    @property
+    def MA(self):
+        return self._MA
+
+    @property
+    def F(self):
+        return self._F
+
+    @property
+    def R(self):
+        return self._R
+
+    @property
+    def r(self):
+        return self._r

--- a/myosuite/mjx/fatigue.py
+++ b/myosuite/mjx/fatigue.py
@@ -2,6 +2,9 @@ import jax.numpy as jp
 import jax
 import jax.random as jrandom
 import mujoco
+from typing import Dict, Tuple, Any
+from jax import tree_util
+import numpy as np
 
 # Constants for floating-point precision
 _FLOAT_EPS = jp.finfo(jp.float32).eps
@@ -14,56 +17,70 @@ class CumulativeFatigue:
     Based on implementation from Aleksi Ikkala and Florian Fischer
     """
     def __init__(self, mj_model, frame_skip=1, key=None):
-        # Recovery time multiplier (10x factor to compensate for 0.1 below)
-        self._r = 10 * 15  
-        
-        # Fatigue coefficient (identified for elbow torque)
-        self._F = jp.array(0.00912, dtype=jp.float32)
-        
-        # Recovery coefficient (0.1 factor to get ~1% R/F ratio)
-        self._R = jp.array(0.1 * 0.00094, dtype=jp.float32)
-        
-        # Timestep including frame skip
-        self._dt = jp.array(mj_model.opt.timestep * frame_skip, dtype=jp.float32)
-        
         # Get muscle actuator indices
         muscle_act_ind = mj_model.actuator_dyntype == mujoco.mjtDyn.mjDYN_MUSCLE
-        self.na = int(jp.sum(muscle_act_ind))  # Number of muscle actuators
+        # Convert to concrete integer value
+        self.na = int(np.sum(muscle_act_ind))  # Use numpy here since we're in __init__
         
-        # Get activation/deactivation time constants for muscles
-        self._tauact = jp.array([
+        # Dynamic arrays (will be included in tree_flatten children)
+        self.MA = jp.zeros(self.na, dtype=jp.float32)  # Muscle Active
+        self.MR = jp.ones(self.na, dtype=jp.float32)   # Muscle Resting
+        self.MF = jp.zeros(self.na, dtype=jp.float32)  # Muscle Fatigue
+        self.TL = jp.zeros(self.na, dtype=jp.float32)  # Target Load
+        
+        # Parameters (will be included in tree_flatten children)
+        self.F = jp.array(0.00912, dtype=jp.float32)  # Fatigue coefficient
+        self.R = jp.array(0.1 * 0.00094, dtype=jp.float32)  # Recovery coefficient
+        self.r = jp.array(10 * 15, dtype=jp.float32)  # Recovery multiplier
+        self.dt = jp.array(mj_model.opt.timestep * frame_skip, dtype=jp.float32)
+        
+        # Get muscle parameters
+        self.tauact = jp.array([
             mj_model.actuator_dynprm[i][0]
             for i in range(len(muscle_act_ind))
             if muscle_act_ind[i]
         ], dtype=jp.float32)
-        
-        self._taudeact = jp.array([
+        self.taudeact = jp.array([
             mj_model.actuator_dynprm[i][1]
             for i in range(len(muscle_act_ind))
             if muscle_act_ind[i]
         ], dtype=jp.float32)
         
-        # Initialize state vectors
-        self._MA = jp.zeros(self.na, dtype=jp.float32)  # Muscle Active
-        self._MR = jp.ones(self.na, dtype=jp.float32)   # Muscle Resting
-        self._MF = jp.zeros(self.na, dtype=jp.float32)  # Muscle Fatigue
-        self.TL = jp.zeros(self.na, dtype=jp.float32)   # Target Load
-        
-        # Initialize RNG
+        # Static values (will be included in aux_data)
         self.key = key
 
-    def set_FatigueCoefficient(self, F):
-        """Set Fatigue coefficient"""
-        self._F = jp.array(F, dtype=jp.float32)
+    def _tree_flatten(self) -> Tuple[Tuple[Any, ...], Dict]:
+        """Flatten the class into children and auxiliary data"""
+        # Dynamic values (arrays that change during computation)
+        children = (
+            self.MA, self.MR, self.MF, self.TL,
+            self.F, self.R, self.r, self.dt,
+            self.tauact, self.taudeact
+        )
+        
+        # Static values
+        aux_data = {
+            'na': self.na,
+            'key': self.key
+        }
+        return (children, aux_data)
 
-    def set_RecoveryCoefficient(self, R):
-        """Set Recovery coefficient"""
-        self._R = jp.array(R, dtype=jp.float32)
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        """Reconstruct class from flattened data"""
+        obj = cls.__new__(cls)  # Create new instance without __init__
+        
+        # Restore dynamic values
+        obj.MA, obj.MR, obj.MF, obj.TL, \
+        obj.F, obj.R, obj.r, obj.dt, \
+        obj.tauact, obj.taudeact = children
+        
+        # Restore static values
+        obj.na = aux_data['na']
+        obj.key = aux_data['key']
+        return obj
 
-    def set_RecoveryMultiplier(self, r):
-        """Set Recovery time multiplier"""
-        self._r = jp.array(r, dtype=jp.float32)
-
+    @jax.jit
     def compute_act(self, act):
         """
         Compute muscle activation considering fatigue
@@ -72,110 +89,143 @@ class CumulativeFatigue:
             act: Target activation levels
             
         Returns:
-            tuple: Updated (MA, MR, MF) states
+            tuple: (MA, MR, MF) states
         """
         # Set target load
         self.TL = jp.array(act, dtype=jp.float32)
         
         # Calculate effective time constants
-        self._LD = 1 / self._tauact * (0.5 + 1.5 * self._MA)
-        self._LR = (0.5 + 1.5 * self._MA) / self._taudeact
+        LD = 1 / self.tauact * (0.5 + 1.5 * self.MA)
+        LR = (0.5 + 1.5 * self.MA) / self.taudeact
         
         # Calculate C(t) - transfer rate between MR and MA
-        C = jp.zeros_like(self._MA)
+        C = jp.zeros_like(self.MA)
         
         # Case 1: MA < TL and MR > (TL - MA)
-        mask1 = (self._MA < self.TL) & (self._MR > (self.TL - self._MA))
-        C = jp.where(mask1, self._LD * (self.TL - self._MA), C)
+        mask1 = (self.MA < self.TL) & (self.MR > (self.TL - self.MA))
+        C = jp.where(mask1, LD * (self.TL - self.MA), C)
         
         # Case 2: MA < TL and MR <= (TL - MA)
-        mask2 = (self._MA < self.TL) & (self._MR <= (self.TL - self._MA))
-        C = jp.where(mask2, self._LD * self._MR, C)
+        mask2 = (self.MA < self.TL) & (self.MR <= (self.TL - self.MA))
+        C = jp.where(mask2, LD * self.MR, C)
         
         # Case 3: MA >= TL
-        mask3 = self._MA >= self.TL
-        C = jp.where(mask3, self._LR * (self.TL - self._MA), C)
+        mask3 = self.MA >= self.TL
+        C = jp.where(mask3, LR * (self.TL - self.MA), C)
         
         # Calculate recovery rate
-        rR = jp.where(self._MA >= self.TL, 
-                     self._r * self._R,
-                     self._R)
+        rR = jp.where(self.MA >= self.TL, 
+                     self.r * self.R,
+                     self.R)
         
         # Clip C(t) to ensure states remain between 0 and 1
         C_min = jp.maximum(
-            -self._MA / self._dt + self._F * self._MA,
-            (self._MR - 1) / self._dt + rR * self._MF
+            -self.MA / self.dt + self.F * self.MA,
+            (self.MR - 1) / self.dt + rR * self.MF
         )
         C_max = jp.minimum(
-            (1 - self._MA) / self._dt + self._F * self._MA,
-            self._MR / self._dt + rR * self._MF
+            (1 - self.MA) / self.dt + self.F * self.MA,
+            self.MR / self.dt + rR * self.MF
         )
         C = jp.clip(C, C_min, C_max)
         
         # Update states
-        dMA = (C - self._F * self._MA) * self._dt
-        dMR = (-C + rR * self._MF) * self._dt
-        dMF = (self._F * self._MA - rR * self._MF) * self._dt
+        dMA = (C - self.F * self.MA) * self.dt
+        dMR = (-C + rR * self.MF) * self.dt
+        dMF = (self.F * self.MA - rR * self.MF) * self.dt
         
-        self._MA = self._MA + dMA
-        self._MR = self._MR + dMR
-        self._MF = self._MF + dMF
+        self.MA = self.MA + dMA
+        self.MR = self.MR + dMR
+        self.MF = self.MF + dMF
         
-        return self._MA, self._MR, self._MF
+        return self.MA, self.MR, self.MF
 
+    @jax.jit
     def get_effort(self):
         """Calculate effort as norm of difference between actual and target activation"""
-        return jp.linalg.norm(self._MA - self.TL)
+        return jp.linalg.norm(self.MA - self.TL)
 
     def reset(self, fatigue_reset_vec=None, fatigue_reset_random=False):
-        """
-        Reset fatigue states
-        
-        Args:
-            fatigue_reset_vec: Optional initial fatigue values
-            fatigue_reset_random: Whether to randomize initial states
-        """
+        """Reset fatigue states"""
         if fatigue_reset_random:
             assert fatigue_reset_vec is None, "Cannot use fatigue_reset_vec if fatigue_reset_random=True"
             self.key, key1, key2 = jrandom.split(self.key, 3)
             non_fatigued_muscles = jrandom.uniform(key1, (self.na,))
             active_percentage = jrandom.uniform(key2, (self.na,))
-            self._MA = non_fatigued_muscles * active_percentage
-            self._MR = non_fatigued_muscles * (1 - active_percentage)
-            self._MF = 1 - non_fatigued_muscles
+            self.MA = non_fatigued_muscles * active_percentage
+            self.MR = non_fatigued_muscles * (1 - active_percentage)
+            self.MF = 1 - non_fatigued_muscles
         else:
             if fatigue_reset_vec is not None:
                 assert len(fatigue_reset_vec) == self.na, \
                     f"Invalid length of fatigue vector (expected {self.na}, got {len(fatigue_reset_vec)})"
-                self._MF = jp.array(fatigue_reset_vec, dtype=jp.float32)
-                self._MR = 1 - self._MF
-                self._MA = jp.zeros(self.na, dtype=jp.float32)
+                self.MF = jp.array(fatigue_reset_vec, dtype=jp.float32)
+                self.MR = 1 - self.MF
+                self.MA = jp.zeros(self.na, dtype=jp.float32)
             else:
-                self._MA = jp.zeros(self.na, dtype=jp.float32)
-                self._MR = jp.ones(self.na, dtype=jp.float32)
-                self._MF = jp.zeros(self.na, dtype=jp.float32)
+                self.MA = jp.zeros(self.na, dtype=jp.float32)
+                self.MR = jp.ones(self.na, dtype=jp.float32)
+                self.MF = jp.zeros(self.na, dtype=jp.float32)
 
-    # Properties
-    @property
-    def MF(self):
-        return self._MF
+    def set_FatigueCoefficient(self, F):
+        """Set Fatigue coefficient"""
+        self.F = jp.array(F, dtype=jp.float32)
 
-    @property
-    def MR(self):
-        return self._MR
+    def set_RecoveryCoefficient(self, R):
+        """Set Recovery coefficient"""
+        self.R = jp.array(R, dtype=jp.float32)
 
-    @property
-    def MA(self):
-        return self._MA
+    def set_RecoveryMultiplier(self, r):
+        """Set Recovery time multiplier"""
+        self.r = jp.array(r, dtype=jp.float32)
 
-    @property
-    def F(self):
-        return self._F
+# Register the class as a PyTree
+tree_util.register_pytree_node(
+    CumulativeFatigue,
+    CumulativeFatigue._tree_flatten,
+    CumulativeFatigue._tree_unflatten
+)
 
-    @property
-    def R(self):
-        return self._R
 
-    @property
-    def r(self):
-        return self._r
+# import cProfile
+# import pstats
+# import io
+
+# def main():
+#     # Create a mock model and key for testing
+#     class MockModel:
+#         def __init__(self):
+#             self.actuator_dyntype = np.array([mujoco.mjtDyn.mjDYN_MUSCLE] * 5)
+#             self.actuator_dynprm = np.array([[0.1, 0.2]] * 5)
+#             self.opt = type('opt', (object,), {'timestep': 0.01})
+
+#     model = MockModel()
+#     key = jrandom.PRNGKey(0)
+
+#     # Initialize the CumulativeFatigue class
+#     fatigue = CumulativeFatigue(model, frame_skip=1, key=key)
+
+#     # Define a batch of test activations
+#     batch_size = 10
+#     test_acts = jp.array([[0.5, 0.6, 0.7, 0.8, 0.9]] * batch_size, dtype=jp.float32)
+
+#     # Define a batched computation using vmap
+#     def batched_compute_act(keys, acts):
+#         def single_compute(key, act):
+#             fatigue_instance = CumulativeFatigue(model, frame_skip=1, key=key)
+#             return fatigue_instance.compute_act(act)
+#         return jax.vmap(single_compute)(keys, acts)
+
+#     # Generate a batch of keys
+#     keys = jrandom.split(key, batch_size)
+
+#     # Profile the batched computation
+#     batched_compute_act(keys, test_acts)
+
+# if __name__ == '__main__':
+#     profiler = cProfile.Profile()
+#     profiler.enable()
+#     main()
+#     profiler.disable()
+#     stats = pstats.Stats(profiler).sort_stats('cumtime')
+#     stats.print_stats(10)  # Print the top 10 functions by cumulative time

--- a/myosuite/tests/mjx/test_fatigue.py
+++ b/myosuite/tests/mjx/test_fatigue.py
@@ -1,4 +1,3 @@
-import pytest 
 import unittest
 import numpy as np
 import jax
@@ -6,9 +5,6 @@ import jax.numpy as jp
 import mujoco
 from functools import partial
 from jax import vmap, jit, tree_util
-
-import cProfile
-import pstats
 
 from myosuite.envs.myo.fatigue import CumulativeFatigue as NumpyCumulativeFatigue
 from myosuite.mjx.fatigue import CumulativeFatigue as JaxCumulativeFatigue
@@ -24,11 +20,10 @@ class TestFatigue(unittest.TestCase):
         cls.frame_skip = 5
         cls.test_act = np.array([0.5]*5, dtype=np.float32)
         cls.test_fatigue_vec = np.array([0.5]*5, dtype=np.float32)
-        cls.key = jax.random.PRNGKey(0)
 
     def test_pytree_structure(self):
         """Test that the class works correctly as a PyTree"""
-        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
         
         # Test flattening and unflattening
         flat, treedef = tree_util.tree_flatten(fatigue)
@@ -45,113 +40,205 @@ class TestFatigue(unittest.TestCase):
         MA2, _, _ = restored.compute_act(self.test_act)
         np.testing.assert_allclose(MA1, MA2)
 
-    def test_jit_compilation(self):
-        """Test that methods can be JIT compiled"""
-        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
+    def test_random_reset(self):
+        """Test random reset with explicit key handling"""
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        key = jax.random.PRNGKey(0)
         
-        # Test compute_act
-        jitted_compute = jax.jit(lambda f, a: f.compute_act(a))
-        MA1, MR1, MF1 = fatigue.compute_act(self.test_act)
-        MA2, MR2, MF2 = jitted_compute(fatigue, self.test_act)
+        # Test random reset
+        fatigue.reset(key=key, fatigue_reset_random=True)
         
-        np.testing.assert_allclose(MA1, MA2)
-        np.testing.assert_allclose(MR1, MR2)
-        np.testing.assert_allclose(MF1, MF2)
+        # Verify states sum to 1
+        total = fatigue.MA + fatigue.MR + fatigue.MF
+        np.testing.assert_allclose(total, jp.ones_like(total))
         
-        # Test get_effort
-        jitted_effort = jax.jit(lambda f: f.get_effort())
-        effort1 = fatigue.get_effort()
-        effort2 = jitted_effort(fatigue)
+        # Test deterministic behavior with same key
+        fatigue2 = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        fatigue2.reset(key=key, fatigue_reset_random=True)
         
-        np.testing.assert_allclose(effort1, effort2)
+        np.testing.assert_allclose(fatigue.MA, fatigue2.MA)
+        np.testing.assert_allclose(fatigue.MR, fatigue2.MR)
+        np.testing.assert_allclose(fatigue.MF, fatigue2.MF)
 
-    def test_vmap_compatibility(self):
-        """Test that the class works with vmap"""
-        profiler = cProfile.Profile()
-        profiler.enable()    
-        batch_size = 2  # Reduced batch size
-        keys = jax.random.split(self.key, batch_size)
-        
-        # Create batch of actions
+    def test_compute_act_vmap(self):
+        """Test that compute_act works with vmap"""
+        batch_size = 2
         batch_acts = jp.stack([self.test_act] * batch_size)
-        
-        #Define batch computation without JIT
+
+        # Define a batched computation using vmap and JIT
         @jax.jit
-        def batch_compute(keys, acts):
-            def single_compute(key, act):
-                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=key)
+        def batch_compute(acts):
+            def single_compute(act):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
                 return fatigue.compute_act(act)
-            return vmap(single_compute)(keys, acts)
-        
+            return jax.vmap(single_compute)(acts)
+
         # Run batch computation
-        batch_MA, batch_MR, batch_MF = batch_compute(keys, batch_acts)
-        
-    
-        # # Verify shapes
-        # self.assertEqual(batch_MA.shape, (batch_size, 5))
-        # self.assertEqual(batch_MR.shape, (batch_size, 5))
-        # self.assertEqual(batch_MF.shape, (batch_size, 5))
-        
+        batch_MA, batch_MR, batch_MF = batch_compute(batch_acts)
+
+        # Verify shapes
+        self.assertEqual(batch_MA.shape, (batch_size, 5))
+        self.assertEqual(batch_MR.shape, (batch_size, 5))
+        self.assertEqual(batch_MF.shape, (batch_size, 5))
+
         # Verify against sequential computation
-        # for i in range(batch_size):
-        #     fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=keys[i])
-        #     MA, MR, MF = fatigue.compute_act(batch_acts[i])
+        for i in range(batch_size):
+            fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+            MA, MR, MF = fatigue.compute_act(batch_acts[i])
+            np.testing.assert_allclose(MA, batch_MA[i])
+            np.testing.assert_allclose(MR, batch_MR[i])
+            np.testing.assert_allclose(MF, batch_MF[i])
+
+    def test_random_reset_vmap(self):
+        """Test that random reset works with vmap"""
+        batch_size = 3
+        key = jax.random.PRNGKey(0)
+        keys = jax.random.split(key, batch_size)
+
+        # Define batched reset function
+        @jax.jit
+        def batch_reset(keys):
+            def single_reset(key):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+                fatigue.reset(key=key, fatigue_reset_random=True)
+                return fatigue.MA, fatigue.MR, fatigue.MF
+            return jax.vmap(single_reset)(keys)
+
+        # Run batch reset
+        batch_MA, batch_MR, batch_MF = batch_reset(keys)
+
+        # Verify shapes
+        self.assertEqual(batch_MA.shape, (batch_size, 5))
+        self.assertEqual(batch_MR.shape, (batch_size, 5))
+        self.assertEqual(batch_MF.shape, (batch_size, 5))
+
+        # Verify states sum to 1 for each instance
+        totals = batch_MA + batch_MR + batch_MF
+        np.testing.assert_allclose(totals, jp.ones_like(totals))
+
+    def test_get_effort_vmap(self):
+        """Test that get_effort works with vmap"""
+        batch_size = 2
+        batch_acts = jp.stack([self.test_act] * batch_size)
+
+        # Define a batched computation using vmap and JIT
+        @jax.jit
+        def batch_effort(acts):
+            def single_effort(act):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+                fatigue.compute_act(act)
+                return fatigue.get_effort()
+            return jax.vmap(single_effort)(acts)
+
+        # Run batch computation
+        batch_efforts = batch_effort(batch_acts)
+
+        # Verify shapes
+        self.assertEqual(batch_efforts.shape, (batch_size,))
+
+        # Verify against sequential computation
+        for i in range(batch_size):
+            fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+            fatigue.compute_act(batch_acts[i])
+            effort = fatigue.get_effort()
+            np.testing.assert_allclose(effort, batch_efforts[i])
+
+    def test_numpy_jax_compute_act(self):
+        """Test that JAX and NumPy compute_act produce the same results"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        
+        # Test sequence of activations
+        test_acts = [
+            np.zeros(5, dtype=np.float32),  # Zero activation
+            np.ones(5, dtype=np.float32),   # Full activation
+            np.array([0.3, 0.5, 0.7, 0.2, 0.8], dtype=np.float32),  # Mixed activation
+            np.array([0.5]*5, dtype=np.float32)  # Uniform activation
+        ]
+        
+        for act in test_acts:
+            numpy_MA, numpy_MR, numpy_MF = numpy_fatigue.compute_act(act)
+            jax_MA, jax_MR, jax_MF = jax_fatigue.compute_act(jp.array(act, dtype=jp.float32))
+            print ("NUMPY", numpy_MA, numpy_MR, numpy_MF)
+            print ("JAX", jax_MA, jax_MR, jax_MF)
+            np.testing.assert_allclose(
+                numpy_MA, np.array(jax_MA), 
+                rtol=1e-5,
+                err_msg=f"MA mismatch for activation {act}"
+            )
+            np.testing.assert_allclose(
+                numpy_MR, np.array(jax_MR), 
+                rtol=1e-5,
+                err_msg=f"MR mismatch for activation {act}"
+            )
+            np.testing.assert_allclose(
+                numpy_MF, np.array(jax_MF), 
+                rtol=1e-5,
+                err_msg=f"MF mismatch for activation {act}"
+            )
+
+    def test_numpy_jax_effort(self):
+        """Test that JAX and NumPy effort calculations match"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        
+        # Test with different activations
+        test_acts = [
+            np.zeros(5, dtype=np.float32),
+            np.ones(5, dtype=np.float32),
+            np.array([0.3, 0.5, 0.7, 0.2, 0.8], dtype=np.float32),
+            np.array([0.5]*5, dtype=np.float32)
+        ]
+        
+        for act in test_acts:
+            # Update states
+            numpy_fatigue.compute_act(act)
+            jax_fatigue.compute_act(act)
             
-            # np.testing.assert_allclose(MA, batch_MA[i])
-            # np.testing.assert_allclose(MR, batch_MR[i])
-            # np.testing.assert_allclose(MF, batch_MF[i])
+            # Compare efforts
+            numpy_effort = numpy_fatigue.get_effort()
+            jax_effort = float(jax_fatigue.get_effort())
+            
+            np.testing.assert_allclose(
+                numpy_effort, 
+                jax_effort, 
+                rtol=1e-5,
+                err_msg=f"Effort mismatch for activation {act}"
+            )
 
-        profiler.disable()
-        stats = pstats.Stats(profiler).sort_stats('cumtime')
-        stats.print_stats(10)
-
-    # def test_numpy_compatibility(self):
-    #     """Test compatibility with numpy implementation"""
-    #     numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
-    #     jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
+    def test_numpy_jax_parameters(self):
+        """Test that JAX and NumPy parameter updates behave the same"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
         
-    #     # Test compute_act
-    #     numpy_MA, numpy_MR, numpy_MF = numpy_fatigue.compute_act(self.test_act)
-    #     jax_MA, jax_MR, jax_MF = jax_fatigue.compute_act(self.test_act)
+        # Test Fatigue coefficient
+        new_F = 0.02
+        numpy_fatigue.set_FatigueCoefficient(new_F)
+        jax_fatigue.set_FatigueCoefficient(new_F)
+        np.testing.assert_allclose(numpy_fatigue.F, float(jax_fatigue.F))
         
-    #     np.testing.assert_allclose(numpy_MA, np.array(jax_MA), rtol=1e-5)
-    #     np.testing.assert_allclose(numpy_MR, np.array(jax_MR), rtol=1e-5)
-    #     np.testing.assert_allclose(numpy_MF, np.array(jax_MF), rtol=1e-5)
+        # Test Recovery coefficient
+        new_R = 0.003
+        numpy_fatigue.set_RecoveryCoefficient(new_R)
+        jax_fatigue.set_RecoveryCoefficient(new_R)
+        np.testing.assert_allclose(numpy_fatigue.R, float(jax_fatigue.R))
         
-    #     # Test effort calculation
-    #     numpy_effort = numpy_fatigue.get_effort()
-    #     jax_effort = float(jax_fatigue.get_effort())
+        # Test Recovery multiplier
+        new_r = 12
+        numpy_fatigue.set_RecoveryMultiplier(new_r)
+        jax_fatigue.set_RecoveryMultiplier(new_r)
+        np.testing.assert_allclose(numpy_fatigue.r, float(jax_fatigue.r))
         
-    #     np.testing.assert_allclose(numpy_effort, jax_effort, rtol=1e-5)
-
-    # def test_state_updates(self):
-    #     """Test that state updates work correctly through PyTree transformations"""
-    #     fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
-        
-    #     # Define a sequence of actions
-    #     actions = [
-    #         np.array([0.1]*5, dtype=np.float32),
-    #         np.array([0.5]*5, dtype=np.float32),
-    #         np.array([0.9]*5, dtype=np.float32)
-    #     ]
-        
-    #     # Run sequence through JIT
-    #     @jax.jit
-    #     def run_sequence(f, acts):
-    #         for act in acts:
-    #             f.compute_act(act)
-    #         return f
-        
-    #     updated_fatigue = run_sequence(fatigue, actions)
-        
-    #     # Verify against sequential computation
-    #     reference_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
-    #     for act in actions:
-    #         reference_fatigue.compute_act(act)
-        
-    #     np.testing.assert_allclose(updated_fatigue.MA, reference_fatigue.MA)
-    #     np.testing.assert_allclose(updated_fatigue.MR, reference_fatigue.MR)
-    #     np.testing.assert_allclose(updated_fatigue.MF, reference_fatigue.MF)
+        # Verify behavior with updated parameters
+        act = np.array([0.5]*5, dtype=np.float32)
+        numpy_MA, _, _ = numpy_fatigue.compute_act(act)
+        jax_MA, _, _ = jax_fatigue.compute_act(act)
+        np.testing.assert_allclose(
+            numpy_MA, 
+            np.array(jax_MA),
+            rtol=1e-5,
+            err_msg="MA mismatch after parameter updates"
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/myosuite/tests/mjx/test_fatigue.py
+++ b/myosuite/tests/mjx/test_fatigue.py
@@ -1,0 +1,194 @@
+import unittest
+import numpy as np
+import jax
+import jax.numpy as jp
+import mujoco
+
+from myosuite.envs.myo.fatigue import CumulativeFatigue as NumpyCumulativeFatigue
+from myosuite.mjx.fatigue import CumulativeFatigue as JaxCumulativeFatigue
+
+# Configure JAX to use CPU for consistent testing
+jax.config.update('jax_platform_name', 'cpu')
+
+class TestFatigue(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data and model"""
+        # Create a minimal mujoco model with muscle actuators
+        cls.model = mujoco.MjModel.from_xml_path('myosuite/simhive/myo_sim/finger/myofinger_v0.xml')
+        
+        # Test parameters
+        cls.frame_skip = 5
+        cls.test_act = np.array([0.5, 0.5, 0.5, 0.5, 0.5], dtype=np.float32)
+        cls.test_fatigue_vec = np.array([0.5, 0.5, 0.5, 0.5, 0.5], dtype=np.float32)
+
+    def setUp(self):
+        """Create fresh instances for each test"""
+        self.numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        self.jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+
+    def test_initialization(self):
+        """Test that both implementations initialize the same way"""
+        # Check dimensions
+        self.assertEqual(self.jax_fatigue.na, self.numpy_fatigue.na)
+        
+        # Check parameters
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.F),
+            self.numpy_fatigue.F,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.R),
+            self.numpy_fatigue.R,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.r),
+            self.numpy_fatigue.r,
+            rtol=1e-5
+        )
+        
+        # Check initial states
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.MA),
+            self.numpy_fatigue.MA,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.MR),
+            self.numpy_fatigue.MR,
+            rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.MF),
+            self.numpy_fatigue.MF,
+            rtol=1e-5
+        )
+
+    def test_compute_act(self):
+        """Test activation computation matches between implementations"""
+        # Test with different activation levels
+        test_acts = [
+            np.zeros(5, dtype=np.float32),  # Zero activation
+            np.ones(5, dtype=np.float32),   # Full activation
+            np.array([0.5]*5, dtype=np.float32),  # Mixed activation
+            np.array([0.5]*5, dtype=np.float32)   # Equal activation
+        ]
+        
+        for act in test_acts:
+            # Compute activations
+            numpy_MA, numpy_MR, numpy_MF = self.numpy_fatigue.compute_act(act)
+            jax_MA, jax_MR, jax_MF = self.jax_fatigue.compute_act(act)
+            
+            # Compare results
+            np.testing.assert_allclose(
+                np.array(jax_MA),
+                numpy_MA,
+                rtol=1e-5,
+                err_msg=f"MA mismatch for activation {act}"
+            )
+            np.testing.assert_allclose(
+                np.array(jax_MR),
+                numpy_MR,
+                rtol=1e-5,
+                err_msg=f"MR mismatch for activation {act}"
+            )
+            np.testing.assert_allclose(
+                np.array(jax_MF),
+                numpy_MF,
+                rtol=1e-5,
+                err_msg=f"MF mismatch for activation {act}"
+            )
+
+    def test_reset(self):
+        """Test reset behavior matches between implementations"""
+        # Test normal reset
+        self.numpy_fatigue.reset()
+        self.jax_fatigue.reset()
+        
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.MA),
+            self.numpy_fatigue.MA,
+            rtol=1e-5
+        )
+        
+        # Test reset with fatigue vector
+        self.numpy_fatigue.reset(fatigue_reset_vec=self.test_fatigue_vec)
+        self.jax_fatigue.reset(fatigue_reset_vec=self.test_fatigue_vec)
+        
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.MF),
+            self.numpy_fatigue.MF,
+            rtol=1e-5
+        )
+
+    def test_get_effort(self):
+        """Test effort calculation matches between implementations"""
+        # Set same activation
+        self.numpy_fatigue.compute_act(self.test_act)
+        self.jax_fatigue.compute_act(self.test_act)
+        
+        # Compare effort
+        np.testing.assert_allclose(
+            float(self.jax_fatigue.get_effort()),
+            self.numpy_fatigue.get_effort(),
+            rtol=1e-5
+        )
+
+    def test_parameter_updates(self):
+        """Test parameter updates behave the same"""
+        # Test fatigue coefficient update
+        new_F = 0.02
+        self.numpy_fatigue.set_FatigueCoefficient(new_F)
+        self.jax_fatigue.set_FatigueCoefficient(new_F)
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.F),
+            self.numpy_fatigue.F,
+            rtol=1e-5
+        )
+        
+        # Test recovery coefficient update
+        new_R = 0.003
+        self.numpy_fatigue.set_RecoveryCoefficient(new_R)
+        self.jax_fatigue.set_RecoveryCoefficient(new_R)
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.R),
+            self.numpy_fatigue.R,
+            rtol=1e-5
+        )
+        
+        # Test recovery multiplier update
+        new_r = 12
+        self.numpy_fatigue.set_RecoveryMultiplier(new_r)
+        self.jax_fatigue.set_RecoveryMultiplier(new_r)
+        np.testing.assert_allclose(
+            np.array(self.jax_fatigue.r),
+            self.numpy_fatigue.r,
+            rtol=1e-5
+        )
+
+    def test_sequential_activations(self):
+        """Test behavior over sequential activations matches"""
+        activation_sequence = [
+            np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
+            np.array([0.5, 0.6, 0.7, 0.8, 0.9], dtype=np.float32),
+            np.array([0.]*5, dtype=np.float32),
+            np.array([1.]*5, dtype=np.float32),
+            np.array([0.5]*5, dtype=np.float32),
+            np.array([-1.0]*5, dtype=np.float32)
+        ]
+        
+        for act in activation_sequence:
+            numpy_MA, _, _ = self.numpy_fatigue.compute_act(act)
+            jax_MA, _, _ = self.jax_fatigue.compute_act(act)
+            
+            np.testing.assert_allclose(
+                np.array(jax_MA),
+                numpy_MA,
+                rtol=1e-5,
+                err_msg=f"Sequential activation mismatch for {act}"
+            )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/myosuite/tests/mjx/test_fatigue.py
+++ b/myosuite/tests/mjx/test_fatigue.py
@@ -1,8 +1,14 @@
+import pytest 
 import unittest
 import numpy as np
 import jax
 import jax.numpy as jp
 import mujoco
+from functools import partial
+from jax import vmap, jit, tree_util
+
+import cProfile
+import pstats
 
 from myosuite.envs.myo.fatigue import CumulativeFatigue as NumpyCumulativeFatigue
 from myosuite.mjx.fatigue import CumulativeFatigue as JaxCumulativeFatigue
@@ -14,181 +20,138 @@ class TestFatigue(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up test data and model"""
-        # Create a minimal mujoco model with muscle actuators
         cls.model = mujoco.MjModel.from_xml_path('myosuite/simhive/myo_sim/finger/myofinger_v0.xml')
-        
-        # Test parameters
         cls.frame_skip = 5
-        cls.test_act = np.array([0.5, 0.5, 0.5, 0.5, 0.5], dtype=np.float32)
-        cls.test_fatigue_vec = np.array([0.5, 0.5, 0.5, 0.5, 0.5], dtype=np.float32)
+        cls.test_act = np.array([0.5]*5, dtype=np.float32)
+        cls.test_fatigue_vec = np.array([0.5]*5, dtype=np.float32)
+        cls.key = jax.random.PRNGKey(0)
 
-    def setUp(self):
-        """Create fresh instances for each test"""
-        self.numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
-        self.jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+    def test_pytree_structure(self):
+        """Test that the class works correctly as a PyTree"""
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
+        
+        # Test flattening and unflattening
+        flat, treedef = tree_util.tree_flatten(fatigue)
+        restored = tree_util.tree_unflatten(treedef, flat)
+        
+        # Check that all attributes are preserved
+        np.testing.assert_allclose(restored.MA, fatigue.MA)
+        np.testing.assert_allclose(restored.MR, fatigue.MR)
+        np.testing.assert_allclose(restored.MF, fatigue.MF)
+        self.assertEqual(restored.na, fatigue.na)
+        
+        # Test that the restored object works correctly
+        MA1, _, _ = fatigue.compute_act(self.test_act)
+        MA2, _, _ = restored.compute_act(self.test_act)
+        np.testing.assert_allclose(MA1, MA2)
 
-    def test_initialization(self):
-        """Test that both implementations initialize the same way"""
-        # Check dimensions
-        self.assertEqual(self.jax_fatigue.na, self.numpy_fatigue.na)
+    def test_jit_compilation(self):
+        """Test that methods can be JIT compiled"""
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
         
-        # Check parameters
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.F),
-            self.numpy_fatigue.F,
-            rtol=1e-5
-        )
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.R),
-            self.numpy_fatigue.R,
-            rtol=1e-5
-        )
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.r),
-            self.numpy_fatigue.r,
-            rtol=1e-5
-        )
+        # Test compute_act
+        jitted_compute = jax.jit(lambda f, a: f.compute_act(a))
+        MA1, MR1, MF1 = fatigue.compute_act(self.test_act)
+        MA2, MR2, MF2 = jitted_compute(fatigue, self.test_act)
         
-        # Check initial states
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.MA),
-            self.numpy_fatigue.MA,
-            rtol=1e-5
-        )
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.MR),
-            self.numpy_fatigue.MR,
-            rtol=1e-5
-        )
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.MF),
-            self.numpy_fatigue.MF,
-            rtol=1e-5
-        )
+        np.testing.assert_allclose(MA1, MA2)
+        np.testing.assert_allclose(MR1, MR2)
+        np.testing.assert_allclose(MF1, MF2)
+        
+        # Test get_effort
+        jitted_effort = jax.jit(lambda f: f.get_effort())
+        effort1 = fatigue.get_effort()
+        effort2 = jitted_effort(fatigue)
+        
+        np.testing.assert_allclose(effort1, effort2)
 
-    def test_compute_act(self):
-        """Test activation computation matches between implementations"""
-        # Test with different activation levels
-        test_acts = [
-            np.zeros(5, dtype=np.float32),  # Zero activation
-            np.ones(5, dtype=np.float32),   # Full activation
-            np.array([0.5]*5, dtype=np.float32),  # Mixed activation
-            np.array([0.5]*5, dtype=np.float32)   # Equal activation
-        ]
+    def test_vmap_compatibility(self):
+        """Test that the class works with vmap"""
+        profiler = cProfile.Profile()
+        profiler.enable()    
+        batch_size = 2  # Reduced batch size
+        keys = jax.random.split(self.key, batch_size)
         
-        for act in test_acts:
-            # Compute activations
-            numpy_MA, numpy_MR, numpy_MF = self.numpy_fatigue.compute_act(act)
-            jax_MA, jax_MR, jax_MF = self.jax_fatigue.compute_act(act)
+        # Create batch of actions
+        batch_acts = jp.stack([self.test_act] * batch_size)
+        
+        #Define batch computation without JIT
+        @jax.jit
+        def batch_compute(keys, acts):
+            def single_compute(key, act):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=key)
+                return fatigue.compute_act(act)
+            return vmap(single_compute)(keys, acts)
+        
+        # Run batch computation
+        batch_MA, batch_MR, batch_MF = batch_compute(keys, batch_acts)
+        
+    
+        # # Verify shapes
+        # self.assertEqual(batch_MA.shape, (batch_size, 5))
+        # self.assertEqual(batch_MR.shape, (batch_size, 5))
+        # self.assertEqual(batch_MF.shape, (batch_size, 5))
+        
+        # Verify against sequential computation
+        # for i in range(batch_size):
+        #     fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=keys[i])
+        #     MA, MR, MF = fatigue.compute_act(batch_acts[i])
             
-            # Compare results
-            np.testing.assert_allclose(
-                np.array(jax_MA),
-                numpy_MA,
-                rtol=1e-5,
-                err_msg=f"MA mismatch for activation {act}"
-            )
-            np.testing.assert_allclose(
-                np.array(jax_MR),
-                numpy_MR,
-                rtol=1e-5,
-                err_msg=f"MR mismatch for activation {act}"
-            )
-            np.testing.assert_allclose(
-                np.array(jax_MF),
-                numpy_MF,
-                rtol=1e-5,
-                err_msg=f"MF mismatch for activation {act}"
-            )
+            # np.testing.assert_allclose(MA, batch_MA[i])
+            # np.testing.assert_allclose(MR, batch_MR[i])
+            # np.testing.assert_allclose(MF, batch_MF[i])
 
-    def test_reset(self):
-        """Test reset behavior matches between implementations"""
-        # Test normal reset
-        self.numpy_fatigue.reset()
-        self.jax_fatigue.reset()
-        
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.MA),
-            self.numpy_fatigue.MA,
-            rtol=1e-5
-        )
-        
-        # Test reset with fatigue vector
-        self.numpy_fatigue.reset(fatigue_reset_vec=self.test_fatigue_vec)
-        self.jax_fatigue.reset(fatigue_reset_vec=self.test_fatigue_vec)
-        
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.MF),
-            self.numpy_fatigue.MF,
-            rtol=1e-5
-        )
+        profiler.disable()
+        stats = pstats.Stats(profiler).sort_stats('cumtime')
+        stats.print_stats(10)
 
-    def test_get_effort(self):
-        """Test effort calculation matches between implementations"""
-        # Set same activation
-        self.numpy_fatigue.compute_act(self.test_act)
-        self.jax_fatigue.compute_act(self.test_act)
+    # def test_numpy_compatibility(self):
+    #     """Test compatibility with numpy implementation"""
+    #     numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+    #     jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
         
-        # Compare effort
-        np.testing.assert_allclose(
-            float(self.jax_fatigue.get_effort()),
-            self.numpy_fatigue.get_effort(),
-            rtol=1e-5
-        )
+    #     # Test compute_act
+    #     numpy_MA, numpy_MR, numpy_MF = numpy_fatigue.compute_act(self.test_act)
+    #     jax_MA, jax_MR, jax_MF = jax_fatigue.compute_act(self.test_act)
+        
+    #     np.testing.assert_allclose(numpy_MA, np.array(jax_MA), rtol=1e-5)
+    #     np.testing.assert_allclose(numpy_MR, np.array(jax_MR), rtol=1e-5)
+    #     np.testing.assert_allclose(numpy_MF, np.array(jax_MF), rtol=1e-5)
+        
+    #     # Test effort calculation
+    #     numpy_effort = numpy_fatigue.get_effort()
+    #     jax_effort = float(jax_fatigue.get_effort())
+        
+    #     np.testing.assert_allclose(numpy_effort, jax_effort, rtol=1e-5)
 
-    def test_parameter_updates(self):
-        """Test parameter updates behave the same"""
-        # Test fatigue coefficient update
-        new_F = 0.02
-        self.numpy_fatigue.set_FatigueCoefficient(new_F)
-        self.jax_fatigue.set_FatigueCoefficient(new_F)
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.F),
-            self.numpy_fatigue.F,
-            rtol=1e-5
-        )
+    # def test_state_updates(self):
+    #     """Test that state updates work correctly through PyTree transformations"""
+    #     fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
         
-        # Test recovery coefficient update
-        new_R = 0.003
-        self.numpy_fatigue.set_RecoveryCoefficient(new_R)
-        self.jax_fatigue.set_RecoveryCoefficient(new_R)
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.R),
-            self.numpy_fatigue.R,
-            rtol=1e-5
-        )
+    #     # Define a sequence of actions
+    #     actions = [
+    #         np.array([0.1]*5, dtype=np.float32),
+    #         np.array([0.5]*5, dtype=np.float32),
+    #         np.array([0.9]*5, dtype=np.float32)
+    #     ]
         
-        # Test recovery multiplier update
-        new_r = 12
-        self.numpy_fatigue.set_RecoveryMultiplier(new_r)
-        self.jax_fatigue.set_RecoveryMultiplier(new_r)
-        np.testing.assert_allclose(
-            np.array(self.jax_fatigue.r),
-            self.numpy_fatigue.r,
-            rtol=1e-5
-        )
-
-    def test_sequential_activations(self):
-        """Test behavior over sequential activations matches"""
-        activation_sequence = [
-            np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
-            np.array([0.5, 0.6, 0.7, 0.8, 0.9], dtype=np.float32),
-            np.array([0.]*5, dtype=np.float32),
-            np.array([1.]*5, dtype=np.float32),
-            np.array([0.5]*5, dtype=np.float32),
-            np.array([-1.0]*5, dtype=np.float32)
-        ]
+    #     # Run sequence through JIT
+    #     @jax.jit
+    #     def run_sequence(f, acts):
+    #         for act in acts:
+    #             f.compute_act(act)
+    #         return f
         
-        for act in activation_sequence:
-            numpy_MA, _, _ = self.numpy_fatigue.compute_act(act)
-            jax_MA, _, _ = self.jax_fatigue.compute_act(act)
-            
-            np.testing.assert_allclose(
-                np.array(jax_MA),
-                numpy_MA,
-                rtol=1e-5,
-                err_msg=f"Sequential activation mismatch for {act}"
-            )
+    #     updated_fatigue = run_sequence(fatigue, actions)
+        
+    #     # Verify against sequential computation
+    #     reference_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip, key=self.key)
+    #     for act in actions:
+    #         reference_fatigue.compute_act(act)
+        
+    #     np.testing.assert_allclose(updated_fatigue.MA, reference_fatigue.MA)
+    #     np.testing.assert_allclose(updated_fatigue.MR, reference_fatigue.MR)
+    #     np.testing.assert_allclose(updated_fatigue.MF, reference_fatigue.MF)
 
 if __name__ == '__main__':
     unittest.main()

--- a/notebooks/fatigue.ipynb
+++ b/notebooks/fatigue.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8c2d6ae2-45de-417c-b7ec-ccb76861ec33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "from jax import tree_util\n",
+    "from jax import vmap, jit, tree_util"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c306aa26-8680-4954-ba18-1c2fe0a700b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CustomClass:\n",
+    "    def __init__(self, x: jnp.ndarray, mul: bool):\n",
+    "        self.x = x\n",
+    "        self.mul = mul\n",
+    "      \n",
+    "    @jit\n",
+    "    def calc(self, y):\n",
+    "        if self.mul:\n",
+    "            return self.x * y\n",
+    "        return y\n",
+    "    \n",
+    "    def _tree_flatten(self):\n",
+    "        children = (self.x,)  # arrays / dynamic values\n",
+    "        aux_data = {'mul': self.mul}  # static values\n",
+    "        return (children, aux_data)\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def _tree_unflatten(cls, aux_data, children):\n",
+    "        return cls(*children, **aux_data)\n",
+    "\n",
+    "\n",
+    "tree_util.register_pytree_node(CustomClass,\n",
+    "                               CustomClass._tree_flatten,\n",
+    "                               CustomClass._tree_unflatten)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5a5d6a15-8000-4b56-b53f-744703f107f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6\n",
+      "3\n",
+      "6\n"
+     ]
+    }
+   ],
+   "source": [
+    "c = CustomClass(2, True)\n",
+    "print(c.calc(3))\n",
+    "\n",
+    "c.mul = False  # mutation is detected\n",
+    "print(c.calc(3))\n",
+    "\n",
+    "c = CustomClass(jnp.array(2), True)  # non-hashable x is supported\n",
+    "print(c.calc(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20021093-569d-4b88-846f-a1bd444c5745",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
1. JAX version for fatigue.py
2. Disable jit compilation of compute_act and get_effort function due to issue in comparable behaviour with numpy version
3. Test cases to make sure both versions work same